### PR TITLE
Provide otherProperties with all meta properties

### DIFF
--- a/epublib-core/src/main/java/nl/siegmann/epublib/epub/PackageDocumentBase.java
+++ b/epublib-core/src/main/java/nl/siegmann/epublib/epub/PackageDocumentBase.java
@@ -67,6 +67,7 @@ public class PackageDocumentBase {
 		String toc = "toc";
 		String version = "version";
 		String scheme = "scheme";
+		String property = "property";
 	}
 	
 	protected interface OPFValues {

--- a/epublib-core/src/main/java/nl/siegmann/epublib/epub/PackageDocumentMetadataReader.java
+++ b/epublib-core/src/main/java/nl/siegmann/epublib/epub/PackageDocumentMetadataReader.java
@@ -1,7 +1,11 @@
 package nl.siegmann.epublib.epub;
 
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
+
+import javax.xml.namespace.QName;
 
 import nl.siegmann.epublib.domain.Author;
 import nl.siegmann.epublib.domain.Date;
@@ -14,6 +18,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.w3c.dom.Document;
 import org.w3c.dom.Element;
+import org.w3c.dom.Node;
 import org.w3c.dom.NodeList;
 
 /**
@@ -46,9 +51,28 @@ class PackageDocumentMetadataReader extends PackageDocumentBase {
 		result.setAuthors(readCreators(metadataElement));
 		result.setContributors(readContributors(metadataElement));
 		result.setDates(readDates(metadataElement));
+		result.setOtherProperties(readOtherProperties(metadataElement));
 		return result;
 	}
 	
+
+	private static Map<QName, String> readOtherProperties(Element metadataElement) {
+		Map<QName, String> result = new HashMap<QName, String>();
+		
+		NodeList metaTags = metadataElement.getElementsByTagNameNS(NAMESPACE_OPF, OPFTags.meta);
+		for (int i = 0; i < metaTags.getLength(); i++) {
+			Node metaNode = metaTags.item(i);
+			Node property = metaNode.getAttributes().getNamedItem(OPFAttributes.property);
+			if (property != null) {
+				String name = property.getNodeValue();
+				String value = metaNode.getTextContent();
+				result.put(new QName(name), value);
+			}
+		}
+		
+		return result;
+	}
+
 
 	private static String getBookIdId(Document document) {
 		Element packageElement = DOMUtil.getFirstElementByTagNameNS(document.getDocumentElement(), NAMESPACE_OPF, OPFTags.packageTag);


### PR DESCRIPTION
Currently there's no way in epublib to read additional properties like the ones defined in [EPUB 3 Fixed-Layout Documents](http://idpf.org/epub/fxl/epub-fxl-20120228.html) 

The `getOtherProperties()` method seems to return always null.  Wouldn't it be usefull to have a way to access all properties of metadata somehow?
