### PR TITLE
Read language property from OPF

### DIFF
--- a/epublib-core/src/main/java/nl/siegmann/epublib/epub/PackageDocumentMetadataReader.java
+++ b/epublib-core/src/main/java/nl/siegmann/epublib/epub/PackageDocumentMetadataReader.java
@@ -51,7 +51,14 @@ class PackageDocumentMetadataReader extends PackageDocumentBase {
 		result.setAuthors(readCreators(metadataElement));
 		result.setContributors(readContributors(metadataElement));
 		result.setDates(readDates(metadataElement));
-		result.setOtherProperties(readOtherProperties(metadataElement));
+        result.setOtherProperties(readOtherProperties(metadataElement));
+
+        Element languageTag = DOMUtil.getFirstElementByTagNameNS(metadataElement, NAMESPACE_DUBLIN_CORE, DCTags.language);
+        if (languageTag != null) {
+            result.setLanguage(DOMUtil.getTextChildrenContent(languageTag));
+        }
+
+
 		return result;
 	}
 	

--- a/epublib-core/src/test/java/nl/siegmann/epublib/epub/PackageDocumentMetadataReaderTest.java
+++ b/epublib-core/src/test/java/nl/siegmann/epublib/epub/PackageDocumentMetadataReaderTest.java
@@ -20,4 +20,29 @@ public class PackageDocumentMetadataReaderTest extends TestCase {
 			assertTrue(false);
 		}
 	}
+
+    public void testReadsLanguage() {
+        Metadata metadata = getMetadata("/opf/test_language.opf");
+        assertEquals("fi", metadata.getLanguage());
+    }
+
+    public void testDefaultsToEnglish() {
+        Metadata metadata = getMetadata("/opf/test_default_language.opf");
+        assertEquals("en", metadata.getLanguage());
+    }
+
+    private Metadata getMetadata(String file) {
+        EpubProcessorSupport epubProcessor = new EpubProcessorSupport();
+        try {
+            Document document = EpubProcessorSupport.createDocumentBuilder().parse(PackageDocumentMetadataReader.class.getResourceAsStream(file));
+            Resources resources = new Resources();
+
+            return PackageDocumentMetadataReader.readMetadata(document, resources);
+        } catch (Exception e) {
+            e.printStackTrace();
+            assertTrue(false);
+
+            return null;
+        }
+    }
 }

--- a/epublib-core/src/test/resources/opf/test_default_language.opf
+++ b/epublib-core/src/test/resources/opf/test_default_language.opf
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<package version="2.0" unique-identifier="ISBN" xmlns="http://www.idpf.org/2007/opf">
+	<metadata xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:opf="http://www.idpf.org/2007/opf">
+		<dc:title>This Dynamic Earth</dc:title>
+		<dc:identifier id="ISBN" opf:scheme="ISBN">this_dynamic_earth-AAH813</dc:identifier>
+		<dc:creator opf:role="aut" opf:file-as="W. Jacquelyne Kious, Robert I. Tilling">W. Jacquelyne Kious, Robert I. Tilling</dc:creator>
+		<dc:contributor opf:role="edt" opf:file-as=""></dc:contributor>
+		<dc:publisher>Infogrid Pacific</dc:publisher>
+		<dc:description></dc:description>
+		<dc:coverage></dc:coverage>
+		<dc:source></dc:source>
+		<dc:date opf:event="original-publication">22-01-2009</dc:date>
+		<dc:rights></dc:rights>
+		<dc:subject></dc:subject>
+	</metadata>
+
+	<manifest>
+	</manifest>
+
+	<spine>
+	</spine>
+</package>

--- a/epublib-core/src/test/resources/opf/test_language.opf
+++ b/epublib-core/src/test/resources/opf/test_language.opf
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<package version="2.0" unique-identifier="ISBN" xmlns="http://www.idpf.org/2007/opf">
+	<metadata xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:opf="http://www.idpf.org/2007/opf">
+		<dc:title>This Dynamic Earth</dc:title>
+		<dc:identifier id="ISBN" opf:scheme="ISBN">this_dynamic_earth-AAH813</dc:identifier>
+		<dc:language>fi</dc:language>
+		<dc:creator opf:role="aut" opf:file-as="W. Jacquelyne Kious, Robert I. Tilling">W. Jacquelyne Kious, Robert I. Tilling</dc:creator>
+		<dc:contributor opf:role="edt" opf:file-as=""></dc:contributor>
+		<dc:publisher>Infogrid Pacific</dc:publisher>
+		<dc:description></dc:description>
+		<dc:coverage></dc:coverage>
+		<dc:source></dc:source>
+		<dc:date opf:event="original-publication">22-01-2009</dc:date>
+		<dc:rights></dc:rights>
+		<dc:subject></dc:subject>
+	</metadata>
+
+	<manifest>
+	</manifest>
+
+	<spine>
+	</spine>
+</package>


### PR DESCRIPTION
Previously, Metadata#getLanguage() always returned the default language (en)
because the language code was not parsed from OPF.
