### PR TITLE
Support for very large epub files.

### DIFF
--- a/epublib-core/src/main/java/nl/siegmann/epublib/domain/ResourceInputStream.java
+++ b/epublib-core/src/main/java/nl/siegmann/epublib/domain/ResourceInputStream.java
@@ -1,0 +1,37 @@
+package nl.siegmann.epublib.domain;
+import java.io.FilterInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.zip.ZipFile;
+
+
+/**
+ * A wrapper class for closing a ZipFile object when the InputStream derived
+ * from it is closed.
+ * 
+ * @author ttopalov
+ * 
+ */
+public class ResourceInputStream extends FilterInputStream {
+
+	private ZipFile zipResource;
+	
+	/**
+	 * Constructor.
+	 * 
+	 * @param in
+	 *            The InputStream object.
+	 * @param f
+	 *            The ZipFile object.
+	 */
+	public ResourceInputStream(InputStream in, ZipFile f) {
+		super(in);
+		zipResource = f;
+	}
+	
+	@Override
+	public void close() throws IOException {
+		super.close();
+		zipResource.close();
+	}
+}


### PR DESCRIPTION
- Allows the data of lazy loaded resources to be accessed without ever being loaded into memory.  This is mandatory when an epub contains larger videos.
- Speeds up the process of finding the ZipEntry of a lazy loaded resource by utilizing the ZipFile's internal directory. This provides a huge increase in speed when an epub with lots of resources is processed.
