### PR TITLE
Cleaned up original patch so it no longer requires Apache IOUtils

### DIFF
--- a/epublib-core/src/main/java/nl/siegmann/epublib/epub/EpubReader.java
+++ b/epublib-core/src/main/java/nl/siegmann/epublib/epub/EpubReader.java
@@ -4,8 +4,10 @@ import java.io.FileInputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.util.Arrays;
+import java.util.Enumeration;
 import java.util.List;
 import java.util.zip.ZipEntry;
+import java.util.zip.ZipFile;
 import java.util.zip.ZipInputStream;
 
 import nl.siegmann.epublib.Constants;
@@ -40,7 +42,11 @@ public class EpubReader {
 	public Book readEpub(ZipInputStream in) throws IOException {
 		return readEpub(in, Constants.CHARACTER_ENCODING);
 	}
-	
+
+    public Book readEpub(ZipFile zipfile) throws IOException {
+        return readEpub(zipfile, Constants.CHARACTER_ENCODING);
+    }
+
 	/**
 	 * Read epub from inputstream
 	 * 
@@ -90,17 +96,24 @@ public class EpubReader {
 	}
 	
 	public Book readEpub(ZipInputStream in, String encoding) throws IOException {
-		Book result = new Book();
-		Resources resources = readResources(in, encoding);
-		handleMimeType(result, resources);
-		String packageResourceHref = getPackageResourceHref(resources);
-		Resource packageResource = processPackageResource(packageResourceHref, result, resources);
-		result.setOpfResource(packageResource);
-		Resource ncxResource = processNcxResource(packageResource, result);
-		result.setNcxResource(ncxResource);
-		result = postProcessBook(result);
-		return result;
+        return readEpubResources(readResources(in, encoding));
 	}
+
+    public Book readEpub(ZipFile in, String encoding) throws IOException {
+        return readEpubResources(readResources(in, encoding));
+    }
+
+    public Book readEpubResources(Resources resources) throws IOException{
+        Book result = new Book();
+        handleMimeType(result, resources);
+        String packageResourceHref = getPackageResourceHref(resources);
+        Resource packageResource = processPackageResource(packageResourceHref, result, resources);
+        result.setOpfResource(packageResource);
+        Resource ncxResource = processNcxResource(packageResource, result);
+        result.setNcxResource(ncxResource);
+        result = postProcessBook(result);
+        return result;
+    }
 
 	private Book postProcessBook(Book book) {
 		if (bookProcessor != null) {
@@ -193,4 +206,22 @@ public class EpubReader {
 		}
 		return result;
 	}
+
+    private Resources readResources(ZipFile zipFile, String defaultHtmlEncoding) throws IOException {
+        Resources result = new Resources();
+        Enumeration<? extends ZipEntry> entries = zipFile.entries();
+
+        while(entries.hasMoreElements()){
+            ZipEntry zipEntry = entries.nextElement();
+            if(zipEntry != null && !zipEntry.isDirectory()){
+                Resource resource = ResourceUtil.createResource(zipEntry, zipFile.getInputStream(zipEntry));
+                if(resource.getMediaType() == MediatypeService.XHTML) {
+                    resource.setInputEncoding(defaultHtmlEncoding);
+                }
+                result.add(resource);
+            }
+        }
+
+        return result;
+    }
 }

--- a/epublib-core/src/main/java/nl/siegmann/epublib/util/ResourceUtil.java
+++ b/epublib-core/src/main/java/nl/siegmann/epublib/util/ResourceUtil.java
@@ -1,10 +1,6 @@
 package nl.siegmann.epublib.util;
 
-import java.io.File;
-import java.io.FileInputStream;
-import java.io.IOException;
-import java.io.Reader;
-import java.io.UnsupportedEncodingException;
+import java.io.*;
 import java.util.zip.ZipEntry;
 import java.util.zip.ZipInputStream;
 
@@ -64,7 +60,11 @@ public class ResourceUtil {
 		return new Resource(zipInputStream, zipEntry.getName());
 
 	}
-		
+
+    public static Resource createResource(ZipEntry zipEntry, InputStream zipInputStream) throws IOException {
+        return new Resource(zipInputStream, zipEntry.getName());
+
+    }
 
 	/**
 	 * Converts a given string from given input character encoding to the requested output character encoding.


### PR DESCRIPTION
Added support for reading epub files directly from a java.zip.ZipFile instead of a ZipInputStream:

the ZipInputStream approach stops reading from the input when a null entry is found, which in some cases leads to a toc-not-found-error.

Conflicts:

```
epublib-core/src/main/java/nl/siegmann/epublib/domain/Resource.java
```
